### PR TITLE
A prototype of vectorized UDAF.

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -97,6 +97,7 @@ private[spark] object PythonEvalType {
   val NON_UDF = 0
   val SQL_BATCHED_UDF = 1
   val SQL_VECTORIZED_UDF = 2
+  val SQL_VECTORIZED_UDAF = 3
 }
 
 /**

--- a/python/pyspark/serializers.py
+++ b/python/pyspark/serializers.py
@@ -589,6 +589,7 @@ class VectorizedSerializer(Serializer):
     def dump_stream(self, iterator, stream):
         import pandas as pd
         import pyarrow as pa
+        write_int(0, stream)
         # the schema is set at worker.py#read_vectorized_udfs
         writer = pa.RecordBatchStreamWriter(stream, self.schema)
         names = self.schema.names

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ArrayDataBuffer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ArrayDataBuffer.scala
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.util
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.types.{DataType, Decimal}
+import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
+
+class ArrayDataBuffer(val buffer: ArrayBuffer[Any]) extends ArrayData {
+
+  def this(initialCapacity: Int) = this(new ArrayBuffer[Any](initialCapacity))
+  def this() = this(new ArrayBuffer[Any]())
+
+  override def copy(): ArrayData = {
+    val newValues = new ArrayBuffer[Any](buffer.length)
+    var i = 0
+    while (i < buffer.length) {
+      newValues(i) = InternalRow.copyValue(buffer(i))
+      i += 1
+    }
+    new ArrayDataBuffer(newValues)
+  }
+
+  override def array: Array[Any] = {
+    val newValues = new Array[Any](buffer.length)
+    var i = 0
+    while (i < buffer.length) {
+      newValues(i) = InternalRow.copyValue(buffer(i))
+      i += 1
+    }
+    newValues
+  }
+
+  override def numElements(): Int = buffer.length
+
+  private def getAs[T](ordinal: Int) = buffer(ordinal).asInstanceOf[T]
+  override def isNullAt(ordinal: Int): Boolean = getAs[AnyRef](ordinal) eq null
+  override def get(ordinal: Int, elementType: DataType): AnyRef = getAs(ordinal)
+  override def getBoolean(ordinal: Int): Boolean = getAs(ordinal)
+  override def getByte(ordinal: Int): Byte = getAs(ordinal)
+  override def getShort(ordinal: Int): Short = getAs(ordinal)
+  override def getInt(ordinal: Int): Int = getAs(ordinal)
+  override def getLong(ordinal: Int): Long = getAs(ordinal)
+  override def getFloat(ordinal: Int): Float = getAs(ordinal)
+  override def getDouble(ordinal: Int): Double = getAs(ordinal)
+  override def getDecimal(ordinal: Int, precision: Int, scale: Int): Decimal = getAs(ordinal)
+  override def getUTF8String(ordinal: Int): UTF8String = getAs(ordinal)
+  override def getBinary(ordinal: Int): Array[Byte] = getAs(ordinal)
+  override def getInterval(ordinal: Int): CalendarInterval = getAs(ordinal)
+  override def getStruct(ordinal: Int, numFields: Int): InternalRow = getAs(ordinal)
+  override def getArray(ordinal: Int): ArrayData = getAs(ordinal)
+  override def getMap(ordinal: Int): MapData = getAs(ordinal)
+
+  override def setNullAt(ordinal: Int): Unit = buffer(ordinal) = null
+
+  override def update(ordinal: Int, value: Any): Unit = buffer(ordinal) = value
+
+  def +=(value: Any): this.type = {
+    buffer += value
+    this
+  }
+
+  def ++=(values: TraversableOnce[Any]): this.type = {
+    buffer ++= values
+    this
+  }
+
+  def ++=(values: ArrayData): this.type = {
+    values match {
+      case buff: ArrayDataBuffer => buffer ++= buff.buffer
+      case _ => buffer ++= values.array
+    }
+    this
+  }
+
+  def clear(): Unit = {
+    buffer.clear()
+  }
+
+  override def toString(): String = buffer.mkString("[", ",", "]")
+
+  override def equals(o: Any): Boolean = {
+    if (!o.isInstanceOf[ArrayDataBuffer]) {
+      return false
+    }
+
+    val other = o.asInstanceOf[ArrayDataBuffer]
+    if (other eq null) {
+      return false
+    }
+
+    val len = numElements()
+    if (len != other.numElements()) {
+      return false
+    }
+
+    var i = 0
+    while (i < len) {
+      if (isNullAt(i) != other.isNullAt(i)) {
+        return false
+      }
+      if (!isNullAt(i)) {
+        val o1 = buffer(i)
+        val o2 = other.buffer(i)
+        o1 match {
+          case b1: Array[Byte] =>
+            if (!o2.isInstanceOf[Array[Byte]] ||
+              !java.util.Arrays.equals(b1, o2.asInstanceOf[Array[Byte]])) {
+              return false
+            }
+          case f1: Float if java.lang.Float.isNaN(f1) =>
+            if (!o2.isInstanceOf[Float] || ! java.lang.Float.isNaN(o2.asInstanceOf[Float])) {
+              return false
+            }
+          case d1: Double if java.lang.Double.isNaN(d1) =>
+            if (!o2.isInstanceOf[Double] || ! java.lang.Double.isNaN(o2.asInstanceOf[Double])) {
+              return false
+            }
+          case _ => if (o1 != o2) {
+            return false
+          }
+        }
+      }
+      i += 1
+    }
+    true
+  }
+
+  override def hashCode: Int = {
+    var result: Int = 37
+    var i = 0
+    val len = numElements()
+    while (i < len) {
+      val update: Int =
+        if (isNullAt(i)) {
+          0
+        } else {
+          buffer(i) match {
+            case b: Boolean => if (b) 0 else 1
+            case b: Byte => b.toInt
+            case s: Short => s.toInt
+            case i: Int => i
+            case l: Long => (l ^ (l >>> 32)).toInt
+            case f: Float => java.lang.Float.floatToIntBits(f)
+            case d: Double =>
+              val b = java.lang.Double.doubleToLongBits(d)
+              (b ^ (b >>> 32)).toInt
+            case a: Array[Byte] => java.util.Arrays.hashCode(a)
+            case other => other.hashCode()
+          }
+        }
+      result = 37 * result + update
+      i += 1
+    }
+    result
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -103,6 +103,7 @@ class QueryExecution(val sparkSession: SparkSession, val logical: LogicalPlan) {
   /** A sequence of rules that will be applied in order to the physical plan before execution. */
   protected def preparations: Seq[Rule[SparkPlan]] = Seq(
     python.ExtractPythonUDFs,
+    python.ExtractPythonUDAFs,
     PlanSubqueries(sparkSession),
     new ReorderJoinPredicates,
     EnsureRequirements(sparkSession.sessionState.conf),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/BatchAggregateEvalPythonExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/BatchAggregateEvalPythonExec.scala
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.python
+
+import java.io.File
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.{SparkEnv, TaskContext}
+import org.apache.spark.api.python.ChainedPythonFunctions
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.types._
+import org.apache.spark.util.Utils
+
+case class BatchAggregateEvalPythonExec(
+    udfs: Seq[PythonUDF],
+    output: Seq[Attribute],
+    child: SparkPlan)
+  extends SparkPlan {
+  assert(udfs.forall(_.vectorized), "cannot use normal udf")
+
+  def children: Seq[SparkPlan] = child :: Nil
+
+  override def producedAttributes: AttributeSet = AttributeSet(output.drop(child.output.length))
+
+  private def collectFunctions(udf: PythonUDF): (ChainedPythonFunctions, Seq[Expression]) = {
+    udf.children match {
+      case Seq(u: PythonUDF) =>
+        val (chained, children) = collectFunctions(u)
+        (ChainedPythonFunctions(chained.funcs ++ Seq(udf.func)), children)
+      case children =>
+        // There should not be any other UDFs, or the children can't be evaluated directly.
+        assert(children.forall(_.find(_.isInstanceOf[PythonUDF]).isEmpty))
+        (ChainedPythonFunctions(Seq(udf.func)), udf.children)
+    }
+  }
+
+  protected override def doExecute(): RDD[InternalRow] = {
+    val inputRDD = child.execute().map(_.copy())
+    val bufferSize = inputRDD.conf.getInt("spark.buffer.size", 65536)
+    val reuseWorker = inputRDD.conf.getBoolean("spark.python.worker.reuse", defaultValue = true)
+
+    inputRDD.mapPartitions { iter =>
+      val context = TaskContext.get()
+
+      // The queue used to buffer input rows so we can drain it to
+      // combine input with output from Python.
+      val queue = HybridRowQueue(context.taskMemoryManager(),
+        new File(Utils.getLocalDir(SparkEnv.get.conf)), child.output.length)
+      context.addTaskCompletionListener({ ctx =>
+        queue.close()
+      })
+
+      val (pyFuncs, inputs) = udfs.map(collectFunctions).unzip
+
+      // flatten all the arguments
+      val allInputs = new ArrayBuffer[Expression]
+      val dataTypes = new ArrayBuffer[DataType]
+      val argOffsets = inputs.map { input =>
+        input.map { e =>
+          if (allInputs.exists(_.semanticEquals(e))) {
+            allInputs.indexWhere(_.semanticEquals(e))
+          } else {
+            allInputs += e
+            dataTypes += e.dataType
+            allInputs.length - 1
+          }
+        }.toArray
+      }.toArray
+      val projection = newMutableProjection(allInputs, child.output)
+      val schema = StructType(dataTypes.zipWithIndex.map {
+        case (dt, index) => StructField(s"c_$index", dt)
+      })
+
+      // For each row, add it to the queue.
+
+      val inputIterator = iter.map { inputRow =>
+        queue.add(inputRow.asInstanceOf[UnsafeRow])
+        projection(inputRow)
+      }
+
+      // Output iterator for results from Python.
+      val outputIterator =
+        new VectorizedPythonRunner(pyFuncs, 10000, bufferSize, reuseWorker, true, argOffsets)
+          .compute(inputIterator, schema, context.partitionId(), context)
+      val joined = new JoinedRow
+      val resultProj = UnsafeProjection.create(output, output)
+
+      outputIterator.map { row =>
+        resultProj(joined(queue.remove(), row))
+      }
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/BatchEvalPythonExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/BatchEvalPythonExec.scala
@@ -127,7 +127,7 @@ case class BatchEvalPythonExec(udfs: Seq[PythonUDF], output: Seq[Attribute], chi
 
         // Output iterator for results from Python.
         val outputIterator =
-          new VectorizedPythonRunner(pyFuncs, 10000, bufferSize, reuseWorker, argOffsets)
+          new VectorizedPythonRunner(pyFuncs, 10000, bufferSize, reuseWorker, false, argOffsets)
             .compute(inputIterator, schema, context.partitionId(), context)
         val joined = new JoinedRow
         val resultProj = UnsafeProjection.create(output, output)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ExtractPythonUDAFs.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ExtractPythonUDAFs.scala
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.python
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.aggregate._
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.{ProjectExec, SparkPlan}
+import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, ObjectHashAggregateExec, SortAggregateExec}
+import org.apache.spark.sql.types.ArrayType
+
+object ExtractPythonUDAFs extends Rule[SparkPlan] with PredicateHelper {
+
+  def isPythonUDAF(aggregateExpression: AggregateExpression): Boolean = {
+    aggregateExpression.aggregateFunction.isInstanceOf[PythonUDAF]
+  }
+
+  def hasPythonUDAF(aggregateExpressions: Seq[AggregateExpression]): Boolean = {
+    aggregateExpressions.exists(isPythonUDAF)
+  }
+
+  def hasPythonUDAF(plan: SparkPlan): Boolean = plan match {
+    case agg: HashAggregateExec if hasPythonUDAF(agg.aggregateExpressions) => true
+    case agg: ObjectHashAggregateExec if hasPythonUDAF(agg.aggregateExpressions) => true
+    case agg: SortAggregateExec if hasPythonUDAF(agg.aggregateExpressions) => true
+    case _ => false
+  }
+
+  def apply(plan: SparkPlan): SparkPlan = plan transformUp {
+    case agg if hasPythonUDAF(agg) =>
+      val groupingExpressions = getGroupingExpressions(agg)
+      val groupingAttributes = groupingExpressions.map(_.toAttribute)
+
+      val aggregateExpressions = getAggregateExpressions(agg)
+      val aggregateAttributes = getAggregateAttributes(agg)
+      val resultExpressions = getResultExpressions(agg)
+
+      val newAggregateExpressions = ArrayBuffer.empty[AggregateExpression] ++ aggregateExpressions
+      val newAggregateAttributes = ArrayBuffer.empty[Attribute] ++ aggregateAttributes
+
+      val buffers = ArrayBuffer.empty[BufferInputs]
+      val udafs = ArrayBuffer.empty[PythonUDF]
+      val resultAttrs = ArrayBuffer.empty[AttributeReference]
+
+      val replacingExprs = mutable.Map.empty[Expression, NamedExpression] ++
+        groupingExpressions.zip(groupingAttributes)
+
+      aggregateExpressions.foreach {
+        case aggExpr if isPythonUDAF(aggExpr) =>
+          val pythonUDAF = aggExpr.aggregateFunction.asInstanceOf[PythonUDAF]
+
+          aggExpr.mode match {
+            case Partial =>
+              newAggregateExpressions -= aggExpr
+              newAggregateAttributes --= pythonUDAF.aggBufferAttributes
+
+              val buffer = buffers.find { buf =>
+                buf.children.length == pythonUDAF.children.length &&
+                  buf.children.zip(pythonUDAF.children).forall { case (c, child) =>
+                    c.semanticEquals(child)
+                  }
+              }.getOrElse {
+                val buf = BufferInputs(pythonUDAF.children)
+                buffers += buf
+
+                newAggregateExpressions += aggExpr.copy(aggregateFunction = buf)
+                newAggregateAttributes ++= buf.aggBufferAttributes
+
+                buf
+              }
+
+              val udaf = PythonUDF(pythonUDAF.udaf.name, pythonUDAF.udaf.partial,
+                pythonUDAF.udaf.bufferType, buffer.aggBufferAttributes, vectorized = true)
+              udafs += udaf
+              val newAttrs = pythonUDAF.inputAggBufferAttributes.map { attr =>
+                val elementType = attr.dataType.asInstanceOf[ArrayType].elementType
+                val newAttr = AttributeReference(attr.name, elementType, attr.nullable)()
+                newAttr -> Alias(CreateArray(Seq(newAttr)), attr.name)()
+              }
+              resultAttrs ++= newAttrs.map(_._1)
+              replacingExprs ++= pythonUDAF.inputAggBufferAttributes.zip(newAttrs.map(_._2))
+
+            case Final =>
+              val buffer = BufferInputs(pythonUDAF.inputAggBufferAttributes.map { attr =>
+                val elementType = attr.dataType.asInstanceOf[ArrayType].elementType
+                AttributeReference(attr.name, elementType, attr.nullable)()
+              })
+
+              newAggregateExpressions.update(
+                newAggregateExpressions.indexOf(aggExpr), aggExpr.copy(aggregateFunction = buffer))
+
+              val bufferOut = AttributeReference("buffer", buffer.dataType, buffer.nullable)()
+              newAggregateAttributes.update(
+                 newAggregateAttributes.indexOf(aggExpr.resultAttribute), bufferOut)
+
+              val udafInputs = buffer.inputAggBufferAttributes.zipWithIndex.map {
+                case (attr, idx) =>
+                  GetStructField(bufferOut, idx, Option(attr.name))
+              }
+              val udaf = PythonUDF(pythonUDAF.udaf.name, pythonUDAF.udaf.evaluate,
+                pythonUDAF.udaf.returnType, udafInputs, vectorized = true)
+              udafs += udaf
+              val newAttr = AttributeReference(udaf.name, udaf.dataType, nullable = true)()
+              resultAttrs += newAttr
+              replacingExprs += aggExpr.resultAttribute -> newAttr
+
+            case _ =>
+          }
+        case aggExpr =>
+          aggExpr.mode match {
+            case Partial =>
+              val af = aggExpr.aggregateFunction
+              replacingExprs ++= af.inputAggBufferAttributes.zip(af.aggBufferAttributes).map {
+                case (attr, buffer) =>
+                  attr -> Alias(buffer, attr.name)(
+                    attr.exprId, attr.qualifier, Option(attr.metadata))
+              }
+            case _ =>
+          }
+      }
+
+      val newAgg = copy(
+        plan = agg,
+        aggregateExpressions = newAggregateExpressions,
+        aggregateAttributes = newAggregateAttributes,
+        resultExpressions = groupingExpressions ++ newAggregateAttributes)
+
+      val exec = BatchAggregateEvalPythonExec(udafs, newAgg.output ++ resultAttrs, newAgg)
+
+      val project = resultExpressions.map {
+        expr => expr.transformUp {
+          case expr if replacingExprs.contains(expr) => replacingExprs(expr)
+        }.asInstanceOf[NamedExpression]
+      }
+
+      ProjectExec(project, exec)
+  }
+
+  def getGroupingExpressions(plan: SparkPlan): Seq[NamedExpression] = plan match {
+    case agg: HashAggregateExec => agg.groupingExpressions
+    case agg: ObjectHashAggregateExec => agg.groupingExpressions
+    case agg: SortAggregateExec => agg.groupingExpressions
+  }
+
+  def getAggregateExpressions(plan: SparkPlan): Seq[AggregateExpression] = plan match {
+    case agg: HashAggregateExec => agg.aggregateExpressions
+    case agg: ObjectHashAggregateExec => agg.aggregateExpressions
+    case agg: SortAggregateExec => agg.aggregateExpressions
+  }
+
+  def getAggregateAttributes(plan: SparkPlan): Seq[Attribute] = plan match {
+    case agg: HashAggregateExec => agg.aggregateAttributes
+    case agg: ObjectHashAggregateExec => agg.aggregateAttributes
+    case agg: SortAggregateExec => agg.aggregateAttributes
+  }
+
+  def getResultExpressions(plan: SparkPlan): Seq[NamedExpression] = plan match {
+    case agg: HashAggregateExec => agg.resultExpressions
+    case agg: ObjectHashAggregateExec => agg.resultExpressions
+    case agg: SortAggregateExec => agg.resultExpressions
+  }
+
+  def copy(
+      plan: SparkPlan,
+      aggregateExpressions: Seq[AggregateExpression],
+      aggregateAttributes: Seq[Attribute],
+      resultExpressions: Seq[NamedExpression]): SparkPlan =
+    plan match {
+      case agg: HashAggregateExec =>
+        agg.copy(
+          aggregateExpressions = aggregateExpressions,
+          aggregateAttributes = aggregateAttributes,
+          resultExpressions = resultExpressions)
+      case agg: ObjectHashAggregateExec =>
+        agg.copy(
+          aggregateExpressions = aggregateExpressions,
+          aggregateAttributes = aggregateAttributes,
+          resultExpressions = resultExpressions)
+      case agg: SortAggregateExec =>
+        agg.copy(
+          aggregateExpressions = aggregateExpressions,
+          aggregateAttributes = aggregateAttributes,
+          resultExpressions = resultExpressions)
+    }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/VectorizedPythonRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/VectorizedPythonRunner.scala
@@ -43,6 +43,7 @@ class VectorizedPythonRunner(
     batchSize: Int,
     bufferSize: Int,
     reuse_worker: Boolean,
+    isUDAF: Boolean,
     argOffsets: Array[Array[Int]]) extends Logging {
 
   require(funcs.length == argOffsets.length, "argOffsets should have the same length as funcs")
@@ -288,8 +289,13 @@ class VectorizedPythonRunner(
         }
         dataOut.flush()
 
-        // SQL_VECTORIZED_UDF means arrow mode
-        dataOut.writeInt(PythonEvalType.SQL_VECTORIZED_UDF)
+        // SQL_VECTORIZED_UDF/SQL_VECTORIZED_UDAF means arrow mode
+        if (isUDAF) {
+          dataOut.writeInt(PythonEvalType.SQL_VECTORIZED_UDAF)
+        }
+        else {
+          dataOut.writeInt(PythonEvalType.SQL_VECTORIZED_UDF)
+        }
         dataOut.writeInt(funcs.length)
         funcs.zip(argOffsets).foreach { case (chained, offsets) =>
           dataOut.writeInt(offsets.length)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/udaf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/udaf.scala
@@ -18,9 +18,13 @@
 package org.apache.spark.sql.execution.python
 
 import org.apache.spark.api.python.PythonFunction
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.Column
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
+import org.apache.spark.sql.catalyst.expressions.codegen.GenerateMutableProjection
+import org.apache.spark.sql.catalyst.util.{ArrayData, ArrayDataBuffer}
 import org.apache.spark.sql.types._
 
 /**
@@ -101,4 +105,105 @@ case class PythonUDAF(
   }
 
   override def nodeName: String = udaf.name
+}
+
+case class BufferInputs(
+    children: Seq[Expression],
+    mutableAggBufferOffset: Int = 0,
+    inputAggBufferOffset: Int = 0)
+  extends ImperativeAggregate
+  with NonSQLExpression
+  with Logging {
+
+  override def withNewMutableAggBufferOffset(newMutableAggBufferOffset: Int): ImperativeAggregate =
+    copy(mutableAggBufferOffset = newMutableAggBufferOffset)
+
+  override def withNewInputAggBufferOffset(newInputAggBufferOffset: Int): ImperativeAggregate =
+    copy(inputAggBufferOffset = newInputAggBufferOffset)
+
+  override def nullable: Boolean = true
+
+  override def dataType: DataType = aggBufferSchema
+
+  override val aggBufferSchema: StructType =
+    StructType(children.zipWithIndex.map {
+      case (child, i) =>
+        StructField(s"_$i", ArrayType(child.dataType, child.nullable), nullable = false)
+    })
+
+  override val aggBufferAttributes: Seq[AttributeReference] = aggBufferSchema.toAttributes
+
+  // Note: although this simply copies aggBufferAttributes, this common code can not be placed
+  // in the superclass because that will lead to initialization ordering issues.
+  override val inputAggBufferAttributes: Seq[AttributeReference] =
+    aggBufferAttributes.map(_.newInstance())
+
+  private[this] lazy val childrenSchema: StructType = {
+    val inputFields = children.zipWithIndex.map {
+      case (child, index) =>
+        StructField(s"input$index", child.dataType, child.nullable, Metadata.empty)
+    }
+    StructType(inputFields)
+  }
+
+  private lazy val inputProjection = {
+    val inputAttributes = childrenSchema.toAttributes
+    log.debug(
+      s"Creating MutableProj: $children, inputSchema: $inputAttributes.")
+    GenerateMutableProjection.generate(children, inputAttributes)
+  }
+
+  override def initialize(buffer: InternalRow): Unit = {
+    aggBufferSchema.zipWithIndex.foreach { case (_, i) =>
+      buffer.update(i + mutableAggBufferOffset, new ArrayDataBuffer())
+    }
+  }
+
+  override def update(buffer: InternalRow, input: InternalRow): Unit = {
+    val projected = inputProjection(input)
+    aggBufferSchema.zip(childrenSchema).zipWithIndex.foreach {
+      case ((StructField(_, dt @ ArrayType(_, _), _, _), childSchema), i) =>
+        val bufferOffset = i + mutableAggBufferOffset
+        val arrayDataBuffer =
+          buffer.get(bufferOffset, dt).asInstanceOf[ArrayDataBuffer]
+        if (projected.isNullAt(i)) {
+          arrayDataBuffer += null
+        } else {
+          arrayDataBuffer += InternalRow.copyValue(projected.get(i, childSchema.dataType))
+        }
+    }
+  }
+
+  override def merge(buffer1: InternalRow, buffer2: InternalRow): Unit = {
+    aggBufferSchema.zipWithIndex.foreach {
+      case (StructField(_, dt @ ArrayType(elementType, _), _, _), i) =>
+        val bufferOffset = i + mutableAggBufferOffset
+        val inputOffset = i + inputAggBufferOffset
+        val arrayDataBuffer1 = buffer1.get(bufferOffset, dt).asInstanceOf[ArrayDataBuffer]
+        buffer2.get(inputOffset, dt) match {
+          case arrayDataBuffer2: UnsafeArrayData =>
+            elementType match {
+              case BooleanType => arrayDataBuffer1 ++= arrayDataBuffer2.toBooleanArray()
+              case ByteType => arrayDataBuffer1 ++= arrayDataBuffer2.toByteArray()
+              case ShortType => arrayDataBuffer1 ++= arrayDataBuffer2.toShortArray()
+              case IntegerType => arrayDataBuffer1 ++= arrayDataBuffer2.toIntArray()
+              case LongType => arrayDataBuffer1 ++= arrayDataBuffer2.toLongArray()
+              case FloatType => arrayDataBuffer1 ++= arrayDataBuffer2.toFloatArray()
+              case DoubleType => arrayDataBuffer1 ++= arrayDataBuffer2.toDoubleArray()
+            }
+          case arrayDataBuffer2: ArrayData =>
+            arrayDataBuffer1 ++= arrayDataBuffer2
+        }
+    }
+  }
+
+  private val row = new GenericInternalRow(aggBufferSchema.size)
+
+  override def eval(buffer: InternalRow): Any = {
+    aggBufferSchema.zipWithIndex.foreach { case (buffSchema, i) =>
+      val bufferOffset = i + mutableAggBufferOffset
+      row.update(i, buffer.get(bufferOffset, buffSchema.dataType))
+    }
+    row
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/udaf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/udaf.scala
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.python
+
+import org.apache.spark.api.python.PythonFunction
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.aggregate._
+import org.apache.spark.sql.types._
+
+/**
+ * A user-defined aggregate Python function. This is used by the Python API.
+ */
+case class UserDefinedAggregatePythonFunction(
+    name: String,
+    evaluate: PythonFunction,
+    returnType: DataType,
+    partial: PythonFunction,
+    bufferType: DataType) {
+
+  /**
+   * Creates a `Column` for this UDAF using given `Column`s as input arguments.
+   *
+   * @since 2.3.0
+   */
+  @scala.annotation.varargs
+  def apply(exprs: Column*): Column = {
+    val aggregateExpression =
+      AggregateExpression(
+        PythonUDAF(exprs.map(_.expr), this),
+        Complete,
+        isDistinct = false)
+    Column(aggregateExpression)
+  }
+
+  /**
+   * Creates a `Column` for this UDAF using the distinct values of the given
+   * `Column`s as input arguments.
+   *
+   * @since 2.3.0
+   */
+  @scala.annotation.varargs
+  def distinct(exprs: Column*): Column = {
+    val aggregateExpression =
+      AggregateExpression(
+        PythonUDAF(exprs.map(_.expr), this),
+        Complete,
+        isDistinct = true)
+    Column(aggregateExpression)
+  }
+}
+
+/**
+ * The internal wrapper used to hook a [[UserDefinedAggregatePythonFunction]] `udaf` in the
+ * internal aggregation code path.
+ */
+case class PythonUDAF(
+    children: Seq[Expression],
+    udaf: UserDefinedAggregatePythonFunction)
+  extends AggregateFunction
+  with Unevaluable
+  with NonSQLExpression
+  with UserDefinedExpression {
+
+  override def nullable: Boolean = true
+
+  override def dataType: DataType = udaf.returnType
+
+  override val aggBufferSchema: StructType = udaf.bufferType match {
+    case StructType(fields) => StructType(fields.map { field =>
+      StructField(s"${udaf.name}.${field.name}",
+        ArrayType(field.dataType, containsNull = field.nullable), nullable = false)
+    })
+    case dt => new StructType().add(udaf.name, ArrayType(dt, containsNull = true), nullable = false)
+  }
+
+  override val aggBufferAttributes: Seq[AttributeReference] = aggBufferSchema.toAttributes
+
+  // Note: although this simply copies aggBufferAttributes, this common code can not be placed
+  // in the superclass because that will lead to initialization ordering issues.
+  override val inputAggBufferAttributes: Seq[AttributeReference] =
+    aggBufferAttributes.map(_.newInstance())
+
+  override def toString: String = {
+    s"${udaf.name}(${children.mkString(",")})"
+  }
+
+  override def nodeName: String = udaf.name
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a prototype of vectorized UDAF.

**Proposed API**

Introduce `@pandas_udaf` decorator (annotation) to define vectorized UDAFs which takes one or more `pandas.Series` and returns one or more scalar values.

We can define vectorized UDAFs if the function is algebraic as:

```python
@pandas_udaf(LongType(), algebraic=True)
def p_sum(v):
    return v.sum()
```

or if the function is not algebraic with additional parameters `partial` and `bufferType` as:

```python
@pandas_udaf(
    DoubleType(),
    algebraic=False,
    partial=lambda v: (v.sum(), len(v)),
    bufferType=StructType().add("sum", LongType()).add("count", LongType()))
def p_avg(sum, count):
    return (sum.sum() / count.sum())
```

We can use it similar to aggregate functions as:

```python
df.groupBy(col('g')).agg(p_sum(col('n')), expr('count(n)'), p_avg(col('n')))
```
